### PR TITLE
Update to mount both boot and rootfs

### DIFF
--- a/mountpi.sh
+++ b/mountpi.sh
@@ -53,18 +53,33 @@ fi
 
 # check if is unmount instruction
 if [ "$UMOUNT" = true ]; then
-  sudo umount $MOUNT_DIR
+  sudo umount $MOUNT_DIR/bootfs
+  sudo umount $MOUNT_DIR/rootfs
   echo 'UNMOUNTED'
   exit 0
 fi
 
 fdisk -l $IMG
 sector=$(fdisk -l $IMG | sed -n -e '/^Sector size/p' | grep -o -E '[0-9]+' | head -1 | sed -e 's/^0\+//')
-echo $sector
-start=$(fdisk -l $IMG | grep "Linux$" | awk '{print $2}')
-echo $start
-offset=$(($sector*$start))
-echo $offset
-mkdir -p $MOUNT_DIR
-mount -v -o offset=$offset -t ext4 $IMG $MOUNT_DIR
+echo sector=$sector
+bootfs_start=$(fdisk -l $IMG | grep "W95 FAT32 (LBA)$" | awk '{print $2}')
+rootfs_start=$(fdisk -l $IMG | grep "Linux$" | awk '{print $2}')
+echo bootfs_start=$bootfs_start
+echo rootfs_start=$rootfs_start
+bootfs_offset=$(($sector*$bootfs_start))
+rootfs_offset=$(($sector*$rootfs_start))
+echo bootfs_offset=$bootfs_offset
+echo rootfs_offset=$rootfs_offset
+bootfs_sectors=$(fdisk -l $IMG | grep "W95 FAT32 (LBA)$" | awk '{print $4}')
+rootfs_sectors=$(fdisk -l $IMG | grep "Linux$" | awk '{print $4}')
+echo bootfs_sectors=$bootfs_sectors
+echo rootfs_sectors=$rootfs_sectors
+bootfs_sizelimit=$(($sector*$bootfs_sectors))
+rootfs_sizelimit=$(($sector*$rootfs_sectors))
+echo bootfs_sizelimit=$bootfs_sizelimit
+echo rootfs_sizelimit=$rootfs_sizelimit
+mkdir -p $MOUNT_DIR/bootfs
+mkdir -p $MOUNT_DIR/rootfs
+mount -v -o loop,offset=$bootfs_offset,sizelimit=$bootfs_sizelimit -t vfat $IMG $MOUNT_DIR/bootfs
+mount -v -o loop,offset=$rootfs_offset,sizelimit=$rootfs_sizelimit -t ext4 $IMG $MOUNT_DIR/rootfs
 echo 'MOUNTED'


### PR DESCRIPTION
Mounting the rootfs is very handy, but if you want to copy in a custom kernel, you need to mount both the boot and root partitions so this is an update to the script to allow this. 